### PR TITLE
package.json: use file extensions for esmodules compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
 	"bin": {
 		"crc32": "./bin/crc32.njs"
 	},
-	"main": "./crc32",
-	"types": "types",
+	"main": "./crc32.js",
+	"types": "./types/index.d.ts",
 	"dependencies": {
 		"printj": "~1.1.0",
 		"exit-on-epipe": "~1.0.1"

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
 	"bin": {
 		"crc32": "./bin/crc32.njs"
 	},
-	"main": "./crc32.js",
-	"types": "./types/index.d.ts",
+	"main": "crc32.js",
+	"types": "types/index.d.ts",
 	"dependencies": {
 		"printj": "~1.1.0",
 		"exit-on-epipe": "~1.0.1"


### PR DESCRIPTION
thanks for this wonderful repository! we use it in @ethereumjs/common

we are just upgrading to esmodules support and found these file extensions necessary to get to the types, we'll put a hotfix in place but thought it would be nice to contribute upstream